### PR TITLE
Allow empty subdirs

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -151,7 +151,7 @@ function wikify() {
 
   while read line
   do 
-    [ -f $line ] && add $line
+    [ -f $line ] && git add $line
   done < /tmp/wikify.txt
 
   echo "**Important**: The Tables of Content are generated. Any change will be overridden on the next update.<br>For more information: [GitHub Wikifier](https://github.com/hybridgroup/GitHub-Wikifier)" > "$subjects/_footer.md"

--- a/pre-commit
+++ b/pre-commit
@@ -151,7 +151,7 @@ function wikify() {
 
   while read line
   do 
-    git add $line
+    [ -f $line ] && add $line
   done < /tmp/wikify.txt
 
   echo "**Important**: The Tables of Content are generated. Any change will be overridden on the next update.<br>For more information: [GitHub Wikifier](https://github.com/hybridgroup/GitHub-Wikifier)" > "$subjects/_footer.md"


### PR DESCRIPTION
If there is no file, there is nothing to git add.  In practice there is no file when the subdir was otherwise empty.
