### PR TITLE
Fix subject to header

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,2 +1,2 @@
-curl https://raw.github.com/hybridgroup/GitHub-Wikifier/master/pre-commit > .git/hooks/pre-commit;
+curl https://raw.githubusercontent.com/hybridgroup/GitHub-Wikifier/master/pre-commit > .git/hooks/pre-commit;
 chmod +x .git/hooks/pre-commit;

--- a/pre-commit
+++ b/pre-commit
@@ -116,8 +116,8 @@ function wikify() {
 
     # Directory write
     if [[ "$depth" -eq "0" ]]; then
-      echo "$(subject_to_header $@.md)"  >> "$subjects/Home.md"
-      echo "$(subject_to_header $@.md)\n---"  > "$@/_sidebar.md"
+      echo "$(subject_to_header $@)"  >> "$subjects/Home.md"
+      echo "$(subject_to_header $@)\n---"  > "$@/_sidebar.md"
       echo "$@.md" >> /tmp/wikify.txt
       echo "$@/_sidebar.md" >> /tmp/wikify.txt
     fi


### PR DESCRIPTION
This fixes #27 [\- Subject in header in _sidebar.md and Home.md should not have .md at the end](/hybridgroup/GitHub-Wikifier/issues/27).
